### PR TITLE
Lift restriction on what an XmlEnumItem Name can hold

### DIFF
--- a/NetBike.Xml.Tests/Contract/XmlContractResolverTests.cs
+++ b/NetBike.Xml.Tests/Contract/XmlContractResolverTests.cs
@@ -18,7 +18,9 @@
             [XmlEnum("0")]
             False,
             [XmlEnum("-")]
-            SomethingElse
+            SomethingElse,
+            [XmlEnum(".")]
+            Dot,
         }
 
         [Test]
@@ -106,6 +108,7 @@
                 .SetItem(TestEnum.True, "true")
                 .SetItem(TestEnum.False, "false")
                 .SetItem(TestEnum.SomethingElse, "somethingElse")
+                .SetItem(TestEnum.Dot, "dot")
                 .BuildContract();
 
             XmlContractAssert.AreEqual(expected, actual);
@@ -256,6 +259,7 @@
                 .SetItem(TestEnum.True, "1")
                 .SetItem(TestEnum.False, "0")
                 .SetItem(TestEnum.SomethingElse, "-")
+                .SetItem(TestEnum.Dot, ".")
                 .BuildContract();
 
             XmlContractAssert.AreEqual(expected, actual);

--- a/NetBike.Xml/Contracts/XmlEnumItem.cs
+++ b/NetBike.Xml/Contracts/XmlEnumItem.cs
@@ -6,22 +6,7 @@
     {
         public XmlEnumItem(long value, string name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            for (var i = 0; i < name.Length; i++)
-            {
-                var symbol = name[i];
-
-                if (!char.IsLetterOrDigit(symbol) && symbol != '-' && symbol != '_' && symbol != ':')
-                {
-                    throw new ArgumentException("Invalid xml name of enum item.");
-                }
-            }
-
-            this.Name = name;
+            this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Value = value;
         }
 


### PR DESCRIPTION
Previously, an `ArgumentException` would be thrown but there's no reason (an no backing unit test) why any name would not be accepted.

Real-life scenario that could not be serialized before this commit because of this restriction:
```csharp
public enum Version
{
    [XmlEnum("1.0")]
    V1,
    [XmlEnum("2.0")]
    V2,
}
```
