### PR TITLE
Fix missing order on collections

### DIFF
--- a/NetBike.Xml.Tests/Contract/XmlContractResolverTests.cs
+++ b/NetBike.Xml.Tests/Contract/XmlContractResolverTests.cs
@@ -196,9 +196,10 @@
 
             var expected = new XmlObjectContractBuilder<TestClassWithCollections>()
                 .SetName("testClassWithCollections")
-                .SetProperty(x => x.Array, p => p.SetName("array"))
+                .SetProperty(x => x.Array, p => p.SetName("array").SetOrder(1))
                 .SetProperty(x => x.GenericList, p => p
                     .SetName("Array2")
+                    .SetOrder(2)
                     .SetItem(new XmlName("Item", "http://example.org")))
                 .Build();
 
@@ -286,10 +287,10 @@
 
         public class TestClassWithCollections
         {
-            [XmlArray]
+            [XmlArray(Order = 1)]
             public string[] Array { get; set; }
 
-            [XmlArray(ElementName = "Array2")]
+            [XmlArray(ElementName = "Array2", Order = 2)]
             [XmlArrayItem(ElementName = "Item", Namespace = "http://example.org")]
             public List<int> GenericList { get; set; }
         }

--- a/NetBike.Xml/Contracts/XmlContractResolver.cs
+++ b/NetBike.Xml/Contracts/XmlContractResolver.cs
@@ -253,7 +253,7 @@
             else if (attributes.Array != null)
             {
                 var name = propertyName.Create(attributes.Array.ElementName, attributes.Array.Namespace);
-                propertyBuilder.SetName(name).SetNullable(attributes.Array.IsNullable).SetCollection(false);
+                propertyBuilder.SetName(name).SetOrder(attributes.Array.Order).SetNullable(attributes.Array.IsNullable).SetCollection(false);
             }
 
             if (attributes.Default != null)


### PR DESCRIPTION
My current workaround for both #17 and #18 is to use this custom `XmlContractResolver`. Unfortunately, it has to use reflection to directly set values of backing fields for get only properties.

```csharp
using System;
using System.Collections.Generic;
using System.Linq;
using System.Reflection;
using System.Xml.Serialization;
using NetBike.Xml.Contracts;

/// <summary>
/// A custom contract resolver that works around multiple bugs in NetBike.Xml
/// </summary>
internal class WorkaroundXmlContractResolver : XmlContractResolver
{
    /// <summary>
    /// Works around https://github.com/netbike/netbike.xml/pull/17
    /// </summary>
    protected override IEnumerable<XmlEnumItem> ResolveEnumItems(Type valueType)
    {
        var fields = valueType.GetFields(BindingFlags.Public | BindingFlags.Static);
        var count = fields.Length;
        var items = new XmlEnumItem[count];

        for (var i = 0; i < count; i++)
        {
            var field = fields[i];
            var name = GetEnumItemName(valueType, field.Name);
            var value = Convert.ToInt64(field.GetRawConstantValue());

            // if (!this.ignoreSystemAttributes) // ignoreSystemAttributes is private
            {
                var xmlEnum = field
                    .GetCustomAttributes(typeof(XmlEnumAttribute), false)
                    .Cast<XmlEnumAttribute>()
                    .FirstOrDefault();

                if (xmlEnum != null)
                {
                    name = xmlEnum.Name;
                }
            }

            XmlEnumItem enumItem;
            try
            {
                enumItem = new XmlEnumItem(value, name);
            }
            catch (ArgumentException exception) when (exception.TargetSite?.DeclaringType == typeof(XmlEnumItem) && exception.TargetSite?.IsConstructor == true)
            {
                // Create with a valid (empty) name and change it just after creation through reflection. Unfortunately, XmlEnumItem is sealed so there's no clean alternative.
                enumItem = new XmlEnumItem(value, "");
                SetBackingFieldValue(enumItem, nameof(enumItem.Name), name);
            }
            items[i] = enumItem;
        }

        return items;
    }

    /// <summary>
    /// Works around https://github.com/netbike/netbike.xml/pull/18
    /// </summary>
    protected override XmlProperty? ResolveProperty(PropertyInfo propertyInfo)
    {
        var property = base.ResolveProperty(propertyInfo);
        if (property != null)
        {
            var order = property.PropertyInfo.GetCustomAttribute<XmlArrayAttribute>()?.Order;
            if (order.HasValue)
            {
                SetBackingFieldValue(property, nameof(property.Order), order.Value);
            }
        }
        return property;
    }

    private static void SetBackingFieldValue(object target, string propertyName, object? value)
    {
        var fieldName = $"<{propertyName}>k__BackingField";
        var type = target.GetType();
        var field = type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new MissingFieldException(type.FullName, fieldName);
        field.SetValue(target, value);
    }
}
```